### PR TITLE
Tag production auto-deploys with deploy time and commit hash

### DIFF
--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -49,3 +49,10 @@ jobs:
           cf push "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" \
             --manifest ./config/manifests/"${{ env.ENV_STUB }}"-manifest.yml \
             --strategy rolling
+
+      - name: Tag deployment
+        run: |
+          export TAG_FOR_RELEASE=prod-release-$(date +%Y-%m-%d-%H-%M)-$(git rev-parse --short HEAD)
+          git tag --force $TAG_FOR_RELEASE
+          git push --force origin refs/tags/$TAG_FOR_RELEASE
+


### PR DESCRIPTION
I find this info useful in the NPQ app for determining what went live and when, largely this is the same as the merge commit time of course but it can also indicate that things failed to deploy inside Git.