### PR TITLE
Add YML file so Dependabot can provide update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/.github/workflows/deploy_to_review_app.yml
+++ b/.github/workflows/deploy_to_review_app.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code

--- a/.github/workflows/destroy_review_app.yml
+++ b/.github/workflows/destroy_review_app.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Having dependabot file PRs for version updates will make it easier to be sure the app stays up to date and secure.

I've also turned review app deploys back on for Dependabot. With this repo being unfamiliar to myself and likely others it's best to be able to see that an update is functioning fully before merging.