### PR TITLE
Update NPQ start dates

### DIFF
--- a/app/views/early-headship-coaching-offer.html
+++ b/app/views/early-headship-coaching-offer.html
@@ -49,7 +49,7 @@ Early headship coaching offer
         <li><a href="https://www.ucl.ac.uk/ioe/departments-and-centres/centres/ucl-centre-educational-leadership/national-professional-qualifications/early-headship-coaching-offer">UCL Institute of Education</a></li>
       </ul>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <p>Speak to your line manager or contact the above providers to express your interest. Your school may be able to help you choose a provider.</p>
 

--- a/app/views/early-years-leadership.html
+++ b/app/views/early-years-leadership.html
@@ -63,7 +63,7 @@ Early years leadership NPQ
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -171,7 +171,7 @@ Early years leadership NPQ
 
       <p>Depending on your type of setting, you may be able to get funding for more than one NPQ. You will only be eligible for funding for each NPQ once though. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/executive-leadership.html
+++ b/app/views/executive-leadership.html
@@ -62,7 +62,7 @@ Executive leadership NPQ
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -179,7 +179,7 @@ Executive leadership NPQ
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/headship.html
+++ b/app/views/headship.html
@@ -62,7 +62,7 @@ Headship NPQ
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -186,7 +186,7 @@ Headship NPQ
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/leading-behaviour-and-culture.html
+++ b/app/views/leading-behaviour-and-culture.html
@@ -62,7 +62,7 @@ Leading behaviour and culture NPQ
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -179,7 +179,7 @@ Leading behaviour and culture NPQ
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/leading-literacy.html
+++ b/app/views/leading-literacy.html
@@ -62,7 +62,7 @@ Leading literacy NPQ
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -174,7 +174,7 @@ Leading literacy NPQ
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/leading-teacher-development.html
+++ b/app/views/leading-teacher-development.html
@@ -62,7 +62,7 @@ Leading teacher development NPQ
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -167,7 +167,7 @@ Leading teacher development NPQ
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/leading-teaching.html
+++ b/app/views/leading-teaching.html
@@ -62,7 +62,7 @@ Leading teaching NPQ
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -165,7 +165,7 @@ Leading teaching NPQ
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/senior-leadership.html
+++ b/app/views/senior-leadership.html
@@ -62,7 +62,7 @@ Senior leadership NPQ
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -187,7 +187,7 @@ Senior leadership NPQ
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/version-2/early-years-leadership-NPQ.html
+++ b/app/views/version-2/early-years-leadership-NPQ.html
@@ -56,7 +56,7 @@
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -148,7 +148,7 @@
 
       <p>Your course provider will be able to give you more details about how the assessment works.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/version-2/executive-leadership.html
+++ b/app/views/version-2/executive-leadership.html
@@ -56,7 +56,7 @@
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -158,7 +158,7 @@
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/version-2/headship.html
+++ b/app/views/version-2/headship.html
@@ -56,7 +56,7 @@
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -158,7 +158,7 @@
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/version-2/leading-behaviour-and-culture.html
+++ b/app/views/version-2/leading-behaviour-and-culture.html
@@ -56,7 +56,7 @@
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -155,7 +155,7 @@
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/version-2/leading-literacy.html
+++ b/app/views/version-2/leading-literacy.html
@@ -56,7 +56,7 @@
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -157,7 +157,7 @@
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/version-2/leading-teacher-development.html
+++ b/app/views/version-2/leading-teacher-development.html
@@ -56,7 +56,7 @@
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -146,7 +146,7 @@
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/version-2/leading-teaching.html
+++ b/app/views/version-2/leading-teaching.html
@@ -56,7 +56,7 @@
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -141,7 +141,7 @@
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 

--- a/app/views/version-2/senior-leadership.html
+++ b/app/views/version-2/senior-leadership.html
@@ -56,7 +56,7 @@
             Next start
           </dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">Autumn 2022 (apply from June)</p>
+            <p class="govuk-body">Spring 2023 (apply now)</p>
           </dd>
         </div>
 
@@ -158,7 +158,7 @@
 
       <p>You can do more than one NPQ, but will only be eligible for funding for each NPQ once. If you withdraw or fail your course you cannot get funded again for the same NPQ.</p>
 
-      <h2 class="govuk-heading-l">Next steps</h2>
+      <h2 class="govuk-heading-l">Apply</h2>
 
       <h3 class="govuk-heading-m">Step 1</h3>
 


### PR DESCRIPTION
## Update NPQ start dates on all NPQ pages with correct information. 

| Before  | After |
| ------------- |:-------------:|
| ![Screenshot 2022-12-05 at 12 47 41](https://user-images.githubusercontent.com/56349171/205640986-2a49e555-6c6e-489f-b4c4-9bf8ff184beb.png)      | ![Screenshot 2022-12-05 at 12 48 31](https://user-images.githubusercontent.com/56349171/205641108-d1d48dba-6d42-45b7-8a47-9c9e1b0984f8.png) 

## Match 'apply' terminology at the bottom of the page, so you know where on the page to look re. how to apply

| Left columns  | Right columns |
| ------------- |:-------------:|
| ![Screenshot 2022-12-05 at 12 53 35](https://user-images.githubusercontent.com/56349171/205642101-4e86ac43-5b91-4147-9862-1820ad56f881.png)      | ![Screenshot 2022-12-05 at 12 54 25](https://user-images.githubusercontent.com/56349171/205642282-92d0cd95-0baf-4421-8513-54068cf82c84.png)     |

## Next steps

Currently you have to scroll right to the bottom to see how to apply. 

I think we should do a contents list so you can jump to apply if you want to/ so you know at a glance where to find info on applying. 

I've chosen not to anchor link from the summary component, as GDS advises against anchor links. 



