### PR TITLE
make subheading more user centred

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -13,7 +13,7 @@
       <div class="govuk-grid-column-three-quarters">
         <h1 class="govuk-heading-xl white-text govuk-!-margin-top-0 govuk-!-margin-bottom-0">Professional development for teachers and leaders</h1>
 
-        <p class="govuk-body govuk-!-font-size-24 govuk-!-margin-top-6 govuk-!-margin-bottom-4 white-text">Choose a professional development option to help you improve your skills, increase your confidence or progress to a more senior role.</p>
+        <p class="govuk-body govuk-!-font-size-24 govuk-!-margin-top-6 govuk-!-margin-bottom-4 white-text">Choose a professional development option to improve your skills, increase your confidence or help you progress to a more senior role.</p>
       </div>
     </div>
   </div>

--- a/app/views/version-2/start.html
+++ b/app/views/version-2/start.html
@@ -12,7 +12,7 @@
 
 <div class="govuk-grid-column-full blue-background govuk-!-padding-top-7 govuk-!-padding-bottom-5 govuk-!-padding-left-5 govuk-!-margin-bottom-5">
   <h1 class="govuk-heading-xl white-text govuk-!-margin-top-0 govuk-!-margin-bottom-0">Professional development for teachers and leaders</h1>
-  <p class="govuk-body govuk-!-font-size-24 govuk-!-margin-top-6 govuk-!-margin-bottom-4 white-text">Choose a professional development option to help you improve your skills, increase your confidence or progress to a more senior role.
+  <p class="govuk-body govuk-!-font-size-24 govuk-!-margin-top-6 govuk-!-margin-bottom-4 white-text">Choose a professional development option to improve your skills, increase your confidence or help you progress to a more senior role.
 
 </p>
 


### PR DESCRIPTION
Update the subheading under the title. 'We' is not the most user-centred way to introduce NPQs to potential participants. 

Make the content more active, e.g. 'choose a...'

**Before:** 

![Screenshot 2022-12-08 at 15 43 50](https://user-images.githubusercontent.com/56349171/206491149-badabcd2-759a-435b-94a4-3903d1c9745c.png)

**After:**

![Screenshot 2022-12-08 at 16 31 37](https://user-images.githubusercontent.com/56349171/206508118-7025daac-e980-485c-aacb-3d3305fba2d9.png)


