### PR TITLE
Edit suitability for NPQEY

### DIFF
--- a/app/views/early-years-leadership.html
+++ b/app/views/early-years-leadership.html
@@ -99,7 +99,7 @@ Early years leadership NPQ
         <li>other early years foundation stage leaders, such as reception class teachers or early years coordinators</li>
       </ul>
 
-      <p>If you work in a school, discuss with your headteacher which NPQ best meets your needs. The other NPQs are designed with school teachers and leaders in mind.</p>
+      <p>If you work in a school, discuss with your headteacher or provider which NPQ best meets your needs. The other NPQs are designed with school teachers and leaders in mind.</p>
 
       <h2 class="govuk-heading-l">What you’ll learn</h2>
 


### PR DESCRIPTION
Changes to the EY 'who this course is for' content as discussed with policy following UR session with Luke.

The user pointed out that the EY course should also be for people like early years coordinators (who may work in schools rather than an early years setting). 

policy advised that although the courses are more geared towards people working in EY settings, people who work in schools like reception teachers and EY coordinators could do the course if they wanted to - but we should perhaps suggest they consider the other NPQs.

![Screenshot 2023-01-20 at 13 37 26](https://user-images.githubusercontent.com/56349171/214009730-c6d2ff79-ce38-4a9c-a761-29c969120ef3.png)
<img width="575" alt="Screenshot 2023-01-20 at 16 48 07" src="https://user-images.githubusercontent.com/56349171/214009847-c24c1038-1311-4b3b-967c-abacbf49a64b.png">

