### PR TITLE
deleted a sentence to remove reference to TRN

### DIFF
--- a/app/views/early-years-leadership.html
+++ b/app/views/early-years-leadership.html
@@ -202,7 +202,7 @@ Early years leadership NPQ
 
       <h3 class="govuk-heading-m">Step 3</h3>
 
-      <p><a href="https://register-national-professional-qualifications.education.gov.uk/">Register with us</a> so we can confirm you’re eligible to take this course for free. This will include needing to register for a Teacher Reference Number (TRN) so we can identify you and track your progress.<p/>
+      <p><a href="https://register-national-professional-qualifications.education.gov.uk/">Register with us</a> so we can confirm you’re eligible to take this course for free.<p/>
 
       <p class="govuk-body govuk-!-margin-bottom-7">We will give your details to your chosen provider once you have registered. They’ll then send you an application form.</p>
 


### PR DESCRIPTION
**Context**

Remove reference to TRN, ready for the TRN-less journey. 

**Before** 

(early years leadership page mentions TRN): 

![Screenshot 2023-02-16 at 11 29 17](https://user-images.githubusercontent.com/56349171/219353136-13a27e0b-1174-42cd-84d5-edd3fc78f768.png)

**After**

(remove reference to TRN): 

![Screenshot 2023-02-16 at 11 31 34](https://user-images.githubusercontent.com/56349171/219353564-4ade4a56-1ffa-4c5f-a8c1-e40a06ee7753.png)
