### PR TITLE
Example of 301 redirect

### DIFF
--- a/server.js
+++ b/server.js
@@ -221,6 +221,11 @@ app.get(/^([^.]+)$/, function (req, res, next) {
   utils.matchRoutes(req, res, next)
 })
 
+app.get("/test-redirect", function (req, res, next) {
+  res.redirect("https://gov.uk", 301)
+})
+
+
 if (useDocumentation) {
   // Documentation  routes
   documentationApp.get(/^([^.]+)$/, function (req, res, next) {


### PR DESCRIPTION
As we are planning to move CPD pages to GOV.UK publisher, we would like to make sure that user and google index will be properly redirected. The redirect have to be `301 Moved Permanently`:
https://developers.google.com/search/docs/crawling-indexing/301-redirects

This is the demo redirect, it does redirects to `gov.uk`: https://cpd-information-review-app-51.london.cloudapps.digital/test-redirect

This PR demonstrates how to set redirection. For example, to redirect https://professional-development-for-teachers-leaders.education.gov.uk/senior-leadership to eg. https://gov.uk/npq/senior-leadership we would need such entry in `server.js` file:
```js
app.get("/senior-leadership", function (req, res, next) {
  res.redirect("https://gov.uk/npq/senior-leadership", 301)
})
```

For the redirect in this PR, the HTTP looks as it should:
```
➜  cpd-information git:(google-redirect-spike) curl -v http://localhost:3001/test-redirect
*   Trying 127.0.0.1:3001...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 3001 (#0)
> GET /test-redirect HTTP/1.1
> Host: localhost:3001
> User-Agent: curl/7.68.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< x-powered-by: Express
< location: https://gov.uk
< vary: Accept
< content-type: text/plain; charset=utf-8
< content-length: 48
< date: Mon, 10 Jul 2023 09:38:07 GMT
< connection: close
<
* Closing connection 0
Moved Permanently. Redirecting to https://gov.uk% 
```