### PR TITLE
remove sentence

### DIFF
--- a/app/views/leading-primary-mathematics.html
+++ b/app/views/leading-primary-mathematics.html
@@ -187,8 +187,6 @@
 
       <p>You’ll also need to apply separately with your training provider. They’ll send you an application form once you’ve registered.</p>
 
-      <p>Training providers will be confirmed in Autumn 2023.</p>
-
     </div>
   </div>
 


### PR DESCRIPTION
Remove the following sentence from the leading primary maths page:

'Training providers will be confirmed in Autumn 2023.'

This is because we've listed the provider so seems a bit incongruous. 

