### PR TITLE
Redirect content to gov.uk

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -1,6 +1,4 @@
 const express = require('express')
 const router = express.Router()
 
-// Add your routes here - above the module.exports line
-
 module.exports = router

--- a/server.js
+++ b/server.js
@@ -184,6 +184,24 @@ if (useV6) {
   app.use('/public/v6/javascripts/govuk/', express.static(path.join(__dirname, '/node_modules/govuk_frontend_toolkit/javascripts/govuk/')))
 }
 
+const redirects = [
+    ["/" , "https://www.gov.uk/guidance/national-professional-qualification-npq-courses"],
+    ["/leading-primary-mathematics", "https://www.gov.uk/guidance/leading-primary-mathematics-national-professional-qualification"],
+    ["/leading-teaching", "https://www.gov.uk/guidance/leading-teaching-national-professional-qualification"],
+    ["/leading-behaviour-and-culture", "https://www.gov.uk/guidance/leading-behaviour-and-culture-national-professional-qualification"],
+    ["/leading-literacy", "https://www.gov.uk/guidance/leading-literacy-national-professional-qualification"],
+    ["/leading-teacher-development", "https://www.gov.uk/guidance/leading-teacher-development-national-professional-qualification"],
+    ["/senior-leadership", "https://www.gov.uk/guidance/senior-leadership-national-professional-qualification"],
+    ["/headship", "https://www.gov.uk/guidance/headship-national-professional-qualification"],
+    ["/executive-leadership", "https://www.gov.uk/guidance/executive-leadership-national-professional-qualification"],
+    ["/early-years-leadership", "https://www.gov.uk/guidance/early-years-leadership-national-professional-qualification"],
+    ["/early-headship-coaching-offer", "https://www.gov.uk/guidance/early-headship-coaching-offer"],
+].forEach(function(fromTo) {
+    app.get(fromTo[0], function (req, res, next) {
+      res.redirect(fromTo[1], 301)
+    })
+})
+
 // Load routes (found in app/routes.js)
 if (typeof (routes) !== 'function') {
   console.log(routes.bind)

--- a/server.js
+++ b/server.js
@@ -202,6 +202,11 @@ const redirects = [
     })
 })
 
+// As we are retiring this app, we want to redirect everything to main page of the GOV.UK guides.
+app.use(function (req, res, next) {
+  res.redirect("https://www.gov.uk/guidance/national-professional-qualification-npq-courses", 301)
+})
+
 // Load routes (found in app/routes.js)
 if (typeof (routes) !== 'function') {
   console.log(routes.bind)


### PR DESCRIPTION
Content links:
https://cpd-information-review-app-61.london.cloudapps.digital/
https://cpd-information-review-app-61.london.cloudapps.digital/leading-primary-mathematics
https://cpd-information-review-app-61.london.cloudapps.digital/leading-teaching
https://cpd-information-review-app-61.london.cloudapps.digital/leading-behaviour-and-culture
https://cpd-information-review-app-61.london.cloudapps.digital/leading-literacy
https://cpd-information-review-app-61.london.cloudapps.digital/leading-teacher-development
https://cpd-information-review-app-61.london.cloudapps.digital/senior-leadership
https://cpd-information-review-app-61.london.cloudapps.digital/headship
https://cpd-information-review-app-61.london.cloudapps.digital/executive-leadership
https://cpd-information-review-app-61.london.cloudapps.digital/early-years-leadership
https://cpd-information-review-app-61.london.cloudapps.digital/early-headship-coaching-offer

Any url that does not fit the above link will be redirected to GOV.UK guidance root page, eg:
https://cpd-information-review-app-61.london.cloudapps.digital/cookies