### PR TITLE
[675] Create redirect to gov.uk

### DIFF
--- a/terraform/domains/environment_domains/.terraform.lock.hcl
+++ b/terraform/domains/environment_domains/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.62.1"
   constraints = "3.62.1"
   hashes = [
+    "h1:3dG3gNv/w2Sad5EOIWSG7JesKKtRhIiQJzgWOdqpaos=",
     "h1:50KMNmLOMfkfnV8iqsozNHXHI+j2QDwwdfBcRZ4/I7k=",
     "h1:DjR9eGTQPL9YX1fF539MPOrKYLrEmBgrGSBYDJo2iNE=",
     "zh:0fa21ac98474f3a2aeab1191628735ddf1fdb0767f935e8b0f7e259a335773cd",

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -6,18 +6,7 @@
       "domains": [
         "apex"
       ],
-      "cached_paths": [
-        "/govuk/assets/*"
-      ],
-      "environment_short": "pd",
-      "origin_hostname": "cpd-information-production.london.cloudapps.digital",
-      "null_host_header": true,
-      "cnames": {
-        "_5872a7d2f85640907322b4642c8be6f0": {
-          "target": "_f01fb8ba8a7a1c1c96bdd9eb4f6a63b3.rdnyqppgxp.acm-validations.aws.",
-          "ttl": 300
-        }
-      }
+      "environment_short": "pd"
     }
   }
 }

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -6,7 +6,14 @@
       "domains": [
         "apex"
       ],
-      "environment_short": "pd"
+      "environment_short": "pd",
+      "redirect_rules": [
+        {
+          "from-domain": "apex",
+          "to-domain": "www.gov.uk",
+          "to-path": "/guidance/national-professional-qualification-npq-courses"
+        }
+      ]
     }
   }
 }

--- a/terraform/domains/environment_domains/config/production_Terrafile
+++ b/terraform/domains/environment_domains/config/production_Terrafile
@@ -1,3 +1,3 @@
 domains:
     source:  "https://github.com/DFE-Digital/terraform-modules"
-    version: "stable"
+    version: "main"

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -7,13 +7,4 @@ module "domains" {
   resource_group_name = each.value.resource_group_name
   domains             = each.value.domains
   environment         = each.value.environment_short
-  host_name           = each.value.origin_hostname
-  null_host_header    = try(each.value.null_host_header, false)
-  cached_paths        = try(each.value.cached_paths, [])
-}
-
-# Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.
-module "dns_records" {
-  source      = "./vendor/modules/domains//dns/records"
-  hosted_zone = var.hosted_zone
 }

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -7,4 +7,5 @@ module "domains" {
   resource_group_name = each.value.resource_group_name
   domains             = each.value.domains
   environment         = each.value.environment_short
+  redirect_rules      = each.value.redirect_rules
 }


### PR DESCRIPTION
## What
Remove paas domains configuration and redirect to the new site on gov.uk

## How to review
Already been deployed: http://professional-development-for-teachers-leaders.education.gov.uk/
